### PR TITLE
Bug fixes with fslmaths usage on Linux

### DIFF
--- a/quality_check.sh
+++ b/quality_check.sh
@@ -17,20 +17,20 @@ QUALITY_CHECK () {
     fsl_motion_outliers -i $2 -o rest_outlier_fd_EV.txt -s rest_motion_fd.txt -p rest_motion_fd.png --fd
 
     #Create a mask for data analysis
-    fslmaths $3 -Tmean mean_image
-    fslmaths mean_mask_image.nii.gz -thrp 45 -bin mean_image_mask.nii.gz
+    fslmaths $3 -Tmean mean_image.nii.gz
+    fslmaths mean_mask_image.nii.gz -thrp 45 -bin mean_image_mask.nii.gz.nii.gz
     echo "Please clean up the mask image"
     fsleyes mean_image mean_image_mask.nii.gz
 
     ## Calculate temporal SNR (tSNR) before correction:
-    fslmaths $2 -mas mean_image_mask_cleaned.nii.gz -Tstd raw_fMRI_std
-    fslmaths $2 -mas mean_image_mask_cleaned.nii.gz -Tmean raw_fMRI_mean
-    fslmaths raw_fMRI_mean.nii.gz -div raw_fMRI_std.nii.gz raw_fMRI_tSNR
+    fslmaths $2 -mas mean_image_mask_cleaned.nii.gz -Tstd raw_fMRI_std.nii.gz
+    fslmaths $2 -mas mean_image_mask_cleaned.nii.gz -Tmean raw_fMRI_mean.nii.gz
+    fslmaths raw_fMRI_mean.nii.gz -div raw_fMRI_std.nii.gz raw_fMRI_tSNR.nii.gz
 
     ## Calculate temporal SNR (tSNR) after correction:
-    fslmaths $3 -mas mean_image_mask_cleaned.nii.gz -Tstd mc_fMRI_std
-    fslmaths $3 -mas mean_image_mask_cleaned.nii.gz -Tmean mc_fMRI_mean
-    fslmaths mc_fMRI_mean.nii.gz -div mc_fMRI_std.nii.gz mc_fMRI_tSNR
+    fslmaths $3 -mas mean_image_mask_cleaned.nii.gz -Tstd mc_fMRI_std.nii.gz
+    fslmaths $3 -mas mean_image_mask_cleaned.nii.gz -Tmean mc_fMRI_mean.nii.gz
+    fslmaths mc_fMRI_mean.nii.gz -div mc_fMRI_std.nii.gz mc_fMRI_tSNR.nii.gz
 
     fslstats -K mean_image_mask_cleaned.nii.gz raw_fMRI_tSNR.nii.gz -n -m > raw_fMRI_tSNR_mean.txt
     fslstats -K mean_image_mask_cleaned.nii.gz mc_fMRI_tSNR.nii.gz -n -m > mc_fMRI_tSNR_mean.txt

--- a/signal_change_map.sh
+++ b/signal_change_map.sh
@@ -67,7 +67,7 @@ SIGNAL_CHANGE_MAPS () {
         # Step 3: Combine all the processed blocks into a single 4D image
         3dTcat -prefix Signal_Change_Map_premask.nii.gz "${processed_images[@]}"
 
-        fslmaths Signal_Change_Map_premask.nii.gz -mas mask_mean_mc_func.nii.gz Signal_Change_Map
+        fslmaths Signal_Change_Map_premask.nii.gz -mas mask_mean_mc_func.nii.gz Signal_Change_Map.nii.gz
 
         echo "All blocks processed and combined into final 4D image: Signal_Change_Map.nii.gz"
 

--- a/smoothing_using_fsl.sh
+++ b/smoothing_using_fsl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 SMOOTHING_using_FSL () {
-    fslmaths ${1} -s 0.24 sm_${1}
-    fslmaths sm_${1} -mas $2 cleaned_sm_${1}
+    fslmaths ${1} -s 0.24 sm_${1}.nii.gz
+    fslmaths sm_${1}.nii.gz -mas $2 cleaned_sm_${1}.nii.gz
 }

--- a/temporal_snr_using_fsl.sh
+++ b/temporal_snr_using_fsl.sh
@@ -3,7 +3,7 @@
 #Function 1
 TEMPORAL_SNR_using_FSL () {
     echo "******* Computing Temporal SNR *******"
-    fslmaths $1 -Tmean rG1_fsl_mean
-    fslmaths $1 -Tstd rG1_fsl_std
-    fslmaths rG1_fsl_mean.nii.gz -div rG1_fsl_std.nii.gz rG1_fsl_tSNR
+    fslmaths $1 -Tmean rG1_fsl_mean.nii.gz
+    fslmaths $1 -Tstd rG1_fsl_std.nii.gz
+    fslmaths rG1_fsl_mean.nii.gz -div rG1_fsl_std.nii.gz rG1_fsl_tSNR.nii.gz
 }


### PR DESCRIPTION
In Linux, when running any fslmaths command, use .nii.gz extension at the end; otherwise, fslmaths will create files only with .nii extensions that might cause scripts to fail on linux (ubuntu).